### PR TITLE
Use new format for gain files

### DIFF
--- a/calibration_sim/utils/gain2toast.py
+++ b/calibration_sim/utils/gain2toast.py
@@ -9,22 +9,42 @@ import sys
 import numpy as np
 from astropy.io import fits
 
+
 def main(args):
     if len(args) < 4 or len(args) % 2 != 0:
         print("Usage: {0} GAIN_FILE1 DETNAME1 [GAIN_FILE2 DETNAME2...] OUTPUT_FILE"
-                .format(os.path.basename(args[0])))
+              .format(os.path.basename(args[0])))
         sys.exit(1)
 
     outputfilename = args[-1]
     filedetpairs = args[1:-1]
 
-    hdus = [fits.PrimaryHDU()]
-    for curinputfile, curdet in zip(filedetpairs[::2], filedetpairs[1::2]):
-        with fits.open(curinputfile) as inpf:
-            gains = inpf['GAINS'].data.field('GAIN')
-            gainn = inpf['GAINS'].data.field('NSAMPLES')
-            ofsn = inpf['OFFSETS'].data.field('NSAMPLES')
-            ofsperiod = inpf['PERIODS'].header['LENGTH']
+    inputfiles = filedetpairs[::2]
+    detectors = filedetpairs[1::2]
+
+    hdus = [
+        fits.PrimaryHDU(),
+        fits.BinTableHDU.from_columns([
+            fits.Column(name='NAME', array=detectors, unit='',
+                        format='{0}A'.format(max([len(x) for x in detectors]))),
+        ]),
+    ]
+    hdus[1].header["EXTNAME"] = "DETECTORS"
+
+    timewritten = False
+    timecolumn = None
+    gaincolumns = None
+    for detidx, curinputfile, curdet in zip(range(len(detectors)), inputfiles, detectors):
+        try:
+            print('Reading file "{0}"...'.format(curinputfile))
+            with fits.open(curinputfile) as inpf:
+                gains = inpf['GAINS'].data.field('GAIN')
+                gainn = inpf['GAINS'].data.field('NSAMPLES')
+                ofsn = inpf['OFFSETS'].data.field('NSAMPLES')
+                ofsperiod = inpf['PERIODS'].header['LENGTH']
+        except FileNotFoundError:
+            print('File "{0}" not found'.format(curinputfile), file=sys.stderr)
+            sys.exit(1)
 
         if ofsperiod == 0.0:
             ofsperiod = 30.0
@@ -43,17 +63,33 @@ def main(args):
                 samplesincurgain = 0
                 gainidx += 1
 
-        cur_hdu = fits.BinTableHDU.from_columns([
-            fits.Column(name='TIME', array=gainstarttime, unit='s', format='1D'),
-            fits.Column(name='GAIN', array=gains, unit='', format='1D'),
+        if not timewritten:
+            cur_hdu = fits.BinTableHDU.from_columns([
+                fits.Column(name='TIME', array=gainstarttime,
+                            unit='s', format='1D'),
             ])
-        cur_hdu.header['EXTNAME'] = curdet
+            cur_hdu.header["EXTNAME"] = "TIMINGS"
+            hdus.append(cur_hdu)
+            timecolumn = gainstarttime
+            timewritten = True
+        else:
+            assert len(timecolumn) == len(gainstarttime), \
+                "Error: the number of gain factors is different among detectors"
+            assert np.allclose(timecolumn, gainstarttime), \
+                "Error: the time of gain samples is inconsistent among detectors"
 
-        hdus.append(cur_hdu)
+        if gaincolumns is None:
+            gaincolumns = gains
+        else:
+            gaincolumns = np.c_[gaincolumns, gains]
 
+    gainhdu = fits.ImageHDU(gaincolumns)
+    gainhdu.header["EXTNAME"] = "GAINS"
+    hdus.append(gainhdu)
     fits.HDUList(hdus).writeto(outputfilename, overwrite=True)
 
     print('File {0} written'.format(outputfilename))
+
 
 if __name__ == '__main__':
     main(sys.argv)


### PR DESCRIPTION
I implemented the new format for gain files suggested by @tskisner (https://github.com/hpc4cmb/toast/pull/250), an example of the new file is available on Edison at

    /global/cscratch1/sd/zonca/pico/cal_sims/201806_boresight_2pix_2years_nofg/out_000/2pix_gains.fits